### PR TITLE
Fix standalone installation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,9 @@
 ## Installation
 
-Prerequisite: install [ROS](http://wiki.ros.org/ROS/Installation).
+Prerequisite: 
+- install [ROS](http://wiki.ros.org/ROS/Installation).
+- install [PyTorch](https://pytorch.org).
+  - install [torchvision](https://pytorch.org/vision/stable/index.html).
 
 If you want to use only semantic cloud segmentation node just build the package in a catkin workspace, for example:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,8 +8,10 @@ If you want to use only semantic cloud segmentation node just build the package 
 mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws/src
 git clone https://github.com/ctu-vras/traversability_estimation
+git clone https://github.com/ctu-vras/cloud_proc
 cd ~/catkin_ws/
-catkin build traversability_estimation
+rosdep install --from-paths /catkin_ws --ignore-src --rosdistro noetic -y
+catkin build
 ```
 
 In case you would like to run geometric cloud segmentation, traversability fusion or image segementation to point cloud projection nodes,

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>ros_numpy</depend>
 
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_generation</build_export_depend>


### PR DESCRIPTION
When installing the package without installing the whole robingas repository, I noticed some missing dependencies.
In this pull request I fixed that and updated the docs. Basically a simple dependency was missing on the package.xml and the installation instructions did not tell that cloud_proc was required. Also, despite being obvious, the documentation didn't list PyTorch and torchvision as dependencies.
Worked in my case. Tested on a Docker container to be sure, and it looks like now it's working. Anyway I suggest someone to test on a clean setup if you wish to merge, just to be sure.